### PR TITLE
feat: convert JSON:API response to CSV

### DIFF
--- a/src/lib/csvUtils.svelte.ts
+++ b/src/lib/csvUtils.svelte.ts
@@ -1,0 +1,21 @@
+export function objectsToCsvString(objs: Object[]) {
+	let rows = [];
+
+	// header row
+	let firstRow = '';
+	for (const key of Object.keys(objs[0])) {
+		firstRow += key + ',';
+	}
+
+	rows.push(firstRow);
+
+	for (const obj of objs) {
+		rows.push(
+			Object.values(obj)
+				.map((val) => JSON.stringify(val).replaceAll(',', ';'))
+				.join(',')
+		);
+	}
+
+	return rows.join('\n');
+}

--- a/src/lib/csvUtils.svelte.ts
+++ b/src/lib/csvUtils.svelte.ts
@@ -1,10 +1,18 @@
 export function objectsToCsvString(objs: Object[]) {
+	if (objs.length < 1) {
+		return {};
+	}
+
 	let rows = [];
 
 	// header row
 	let firstRow = '';
-	for (const key of Object.keys(objs[0])) {
-		firstRow += key + ',';
+	const keys = Object.keys(objs[0]);
+	for (let i = 0; i < keys.length; i++) {
+		firstRow += keys[i];
+		if (i < keys.length - 1) {
+			firstRow += ',';
+		}
 	}
 
 	rows.push(firstRow);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -158,8 +158,11 @@
 		const file = new Blob([csvString], { type: 'text/csv' });
 
 		const downloadLink = document.createElement('a');
-		downloadLink.download = 'test.csv';
+		const serializedTime = new Date().toISOString();
+		downloadLink.download = `${requestUrl}-${serializedTime}.csv`;
 		const url = window.URL.createObjectURL(file);
+
+		// TODO: is there a more idiomatic way to do this in svelte?
 		downloadLink.href = url;
 		downloadLink.setAttribute('display', 'none');
 		document.body.appendChild(downloadLink);
@@ -221,13 +224,14 @@
 			<p>Loading...</p>
 		{:then data}
 			{#if Array.isArray(data.data)}
-				<a
-					href="/"
+				<button
 					onclick={(e) => {
-						e.preventDefault();
 						downloadCsv(data.data);
-					}}>Download attributes as a CSV</a
+					}}>Download attributes as a CSV</button
 				>
+				<br />
+				<br />
+
 				<table class="japi-data">
 					<thead>
 						<tr>
@@ -399,6 +403,6 @@
 
 	.table-container {
 		overflow: scroll;
-		max-height: 500px;
+		max-height: 1000px;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,8 @@
 	import FilterInput from '../lib/FilterInput.svelte';
 	import { base } from '$app/paths';
 
+	import { objectsToCsvString } from '../lib/csvUtils.svelte.ts';
+
 	import { onMount } from 'svelte';
 
 	interface RelationshipData {
@@ -142,6 +144,28 @@
 		e.preventDefault();
 		requestUrl = buildRequestUrl(apiUrl, resource, resourceId, filters, includes);
 	}
+
+	function downloadCsv(data) {
+		const objs = data.map((d) => {
+			return {
+				id: d.id,
+				...d.attributes
+			};
+		});
+
+		const csvString = objectsToCsvString(objs);
+
+		const file = new Blob([csvString], { type: 'text/csv' });
+
+		const downloadLink = document.createElement('a');
+		downloadLink.download = 'test.csv';
+		const url = window.URL.createObjectURL(file);
+		downloadLink.href = url;
+		downloadLink.setAttribute('display', 'none');
+		document.body.appendChild(downloadLink);
+		downloadLink.click();
+		document.body.removeChild(downloadLink);
+	}
 </script>
 
 <header>
@@ -197,6 +221,13 @@
 			<p>Loading...</p>
 		{:then data}
 			{#if Array.isArray(data.data)}
+				<a
+					href="/"
+					onclick={(e) => {
+						e.preventDefault();
+						downloadCsv(data.data);
+					}}>Download attributes as a CSV</a
+				>
 				<table class="japi-data">
 					<thead>
 						<tr>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -225,7 +225,7 @@
 		{:then data}
 			{#if Array.isArray(data.data)}
 				<button
-					onclick={(e) => {
+					onclick={() => {
 						downloadCsv(data.data);
 					}}>Download attributes as a CSV</button
 				>

--- a/src/test/csvUtils.test.ts
+++ b/src/test/csvUtils.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, describe } from 'vitest';
+
+import { objectsToCsvString } from '../lib/csvUtils.svelte.ts';
+
+describe('objectsToCsvString', () => {
+	test('serializes to csv', () => {
+		const objs = [
+			{ foo: 'bar', baz: 'bop' },
+			{ foo: '1', baz: { a: 'b', c: 'd' } }
+		];
+
+		expect(objectsToCsvString(objs)).toBe('foo,baz\n"bar","bop"\n"1",{"a":"b";"c":"d"}');
+	});
+});


### PR DESCRIPTION
Problem:
Some users would like to download the results of their query as a CSV.

Solution:
Serialize the `attributes` and `id` for each object in `data` in a `JSON:API` response into a CSV. This excludes the `relationships`, and I am not deserializing nested JSON documents - I just leave everything beyond the top level of attributes as JSON.